### PR TITLE
Revert "Added compiler compilation to travis"

### DIFF
--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -2,14 +2,9 @@
 
 # Navigate to our project dir
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$DIR"
+cd ..
 
 # Test build simulator
-cd "$DIR/.."
 cd simulator/
-make -j2
-
-# Test build the compiler
-cd "$DIR/.."
-cd compiler/min-caml/
-bash ./to_sparc
 make -j2


### PR DESCRIPTION
This reverts commit 7e2b1bc43568a67af0ca3a9b12d30bce9351c464.
It broke travis as compiler/ is not compiling yet.